### PR TITLE
Add ndn-svs to webapp

### DIFF
--- a/public/projects.json
+++ b/public/projects.json
@@ -3,31 +3,31 @@
     "name": "ndn-cxx"
   },
   {
-    "name": "NFD"
-  },
-  {
     "name": "ChronoSync"
   },
   {
-    "name": "PSync"
+    "name": "NFD"
   },
   {
     "name": "NLSR"
   },
   {
+    "name": "PSync"
+  },
+  {
+    "name": "name-based-access-control"
+  },
+  {
     "name": "ndn-tools"
+  },
+  {
+    "name": "ndn-traffic-generator"
   },
   {
     "name": "ndncert"
   },
   {
     "name": "ndns"
-  },
-  {
-    "name": "ndn-traffic-generator"
-  },
-  {
-    "name": "name-based-access-control"
   },
   {
     "name": "repo-ng"

--- a/public/projects.json
+++ b/public/projects.json
@@ -1,66 +1,35 @@
 [
   {
-    "name": "ndn-cxx",
-    "skip_job": true
+    "name": "ndn-cxx"
   },
   {
-    "name": "NFD",
-    "depends": [
-      "ndn-cxx"
-    ]
+    "name": "NFD"
   },
   {
-    "name": "ChronoSync",
-    "depends": [
-      "ndn-cxx"
-    ]
+    "name": "ChronoSync"
   },
   {
-    "name": "PSync",
-    "depends": [
-      "ndn-cxx"
-    ]
+    "name": "PSync"
   },
   {
-    "name": "NLSR",
-    "depends": [
-      "PSync"
-    ]
+    "name": "NLSR"
   },
   {
-    "name": "ndn-tools",
-    "depends": [
-      "ndn-cxx"
-    ]
+    "name": "ndn-tools"
   },
   {
-    "name": "ndncert",
-    "depends": [
-      "ndn-cxx"
-    ]
+    "name": "ndncert"
   },
   {
-    "name": "ndns",
-    "depends": [
-      "ndn-cxx"
-    ]
+    "name": "ndns"
   },
   {
-    "name": "ndn-traffic-generator",
-    "depends": [
-      "ndn-cxx"
-    ]
+    "name": "ndn-traffic-generator"
   },
   {
-    "name": "name-based-access-control",
-    "depends": [
-      "ndn-cxx"
-    ]
+    "name": "name-based-access-control"
   },
   {
-    "name": "repo-ng",
-    "depends": [
-      "ndn-cxx"
-    ]
+    "name": "repo-ng"
   }
 ]

--- a/public/projects.json
+++ b/public/projects.json
@@ -18,6 +18,9 @@
     "name": "name-based-access-control"
   },
   {
+    "name": "ndn-svs"
+  },
+  {
     "name": "ndn-tools"
   },
   {


### PR DESCRIPTION
This is the basic stuff (and it's untested). I wanted to do a couple more changes (see below) but I'm not sure I want to deal with this web crap right now.

- [ ] Disallow skipping ndn-cxx (it doesn't make sense)
  - This could be a `skippable` flag in `projects.json` or simply hardcode a special case for ndn-cxx
- [ ] Treat ndn-svs differently since it's not a gerrit project
  - Either disable the "specific patchset" box or change it to accept a github PR number (the CI side in #10 already supports it)
- [ ] Rename "master" to "default"
- [ ] Swap the "skip project" and "specific patchset" columns (no specific reason, it just feels more natural to me)